### PR TITLE
Feat/#1/push

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,8 @@ dependencies {
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
 	implementation 'com.google.cloud:google-cloud-storage:2.33.0'
-	//implementation 'com.google.cloud:spring-cloud-gcp-starter:5.0.2'
+
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'app.iris'
-version = '0.0.5'
+version = '0.0.7'
 
 java {
 	sourceCompatibility = '17'

--- a/src/main/java/app/iris/missingyou/config/AppConfig.java
+++ b/src/main/java/app/iris/missingyou/config/AppConfig.java
@@ -16,7 +16,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.Key;

--- a/src/main/java/app/iris/missingyou/config/AppConfig.java
+++ b/src/main/java/app/iris/missingyou/config/AppConfig.java
@@ -3,6 +3,9 @@ package app.iris.missingyou.config;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,7 +16,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.Key;
 
 @Configuration
@@ -50,5 +55,20 @@ public class AppConfig {
                 .setCredentials(credentials)
                 .build()
                 .getService();
+    }
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging(@Value("${firebase.secret.key}") String secretPath) throws IOException {
+        PathResource resource = new PathResource(secretPath);
+        InputStream refreshToken = resource.getInputStream();
+
+
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(refreshToken))
+                .build();
+
+        FirebaseApp.initializeApp(options);
+
+        return FirebaseMessaging.getInstance();
     }
 }

--- a/src/main/java/app/iris/missingyou/controller/AuthController.java
+++ b/src/main/java/app/iris/missingyou/controller/AuthController.java
@@ -1,18 +1,14 @@
 package app.iris.missingyou.controller;
 
-import app.iris.missingyou.dto.MemberInfoDto;
 import app.iris.missingyou.dto.TokenDto;
 import app.iris.missingyou.entity.Member;
 import app.iris.missingyou.entity.Platform;
-import app.iris.missingyou.security.CustomUserDetails;
 import app.iris.missingyou.security.GoogleUser;
 import app.iris.missingyou.security.OAuth2Service;
 import app.iris.missingyou.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -39,16 +35,6 @@ public class AuthController {
     @GetMapping(value = "/auth/refresh")
     public ResponseEntity<TokenDto> reIssueToken(@RequestHeader(required = true, name = "refreshToken") String refreshToken) {
         TokenDto dto = memberService.reIssueToken(refreshToken);
-        return ResponseEntity.ok().body(dto);
-    }
-
-    @Operation(summary = "유저 정보 요청", security = { @SecurityRequirement(name = "bearerAuth")})
-    @GetMapping(value = "/member")
-    public ResponseEntity<MemberInfoDto> getUserInfo() {
-        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-
-        MemberInfoDto dto = memberService.get(principal);
-
         return ResponseEntity.ok().body(dto);
     }
 }

--- a/src/main/java/app/iris/missingyou/controller/MemberController.java
+++ b/src/main/java/app/iris/missingyou/controller/MemberController.java
@@ -1,20 +1,24 @@
 package app.iris.missingyou.controller;
 
 import app.iris.missingyou.dto.MemberInfoDto;
+import app.iris.missingyou.dto.PushInfoDto;
 import app.iris.missingyou.security.CustomUserDetails;
 import app.iris.missingyou.service.MemberService;
+import app.iris.missingyou.service.FCMService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
 public class MemberController {
     private final MemberService memberService;
+    private final FCMService pushService;
 
     @Operation(summary = "유저 정보 요청", security = { @SecurityRequirement(name = "bearerAuth")})
     @GetMapping(value = "/member")
@@ -24,5 +28,27 @@ public class MemberController {
         MemberInfoDto dto = memberService.get(principal);
 
         return ResponseEntity.ok().body(dto);
+    }
+
+    @Operation(summary = "푸시 알림 정보 생성/수정", security = { @SecurityRequirement(name = "bearerAuth")})
+    @PutMapping(value = "/members/push", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> postPushInfo(
+            @RequestBody PushInfoDto dto
+            ) {
+        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        pushService.setPushInfo(principal, dto);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "푸시 알림 정보 삭제", security = { @SecurityRequirement(name = "bearerAuth")})
+    @DeleteMapping(value = "/members/push")
+    public ResponseEntity<?> postPushInfo() {
+        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        pushService.delete(principal);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/app/iris/missingyou/controller/MemberController.java
+++ b/src/main/java/app/iris/missingyou/controller/MemberController.java
@@ -49,6 +49,18 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
+    @Operation(summary = "디바이스 토큰(기기 등록 토큰) 생성/수정(refresh)", security = { @SecurityRequirement(name = "bearerAuth")})
+    @PutMapping(value = "/members/push/device-token", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> postPushInfo(
+            @RequestBody String deviceToken
+    ) {
+        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        pushService.setDeviceToken(principal, deviceToken);
+
+        return ResponseEntity.ok().build();
+    }
+
     @Operation(summary = "푸시 알림 정보 삭제", security = { @SecurityRequirement(name = "bearerAuth")})
     @DeleteMapping(value = "/members/push")
     public ResponseEntity<?> postPushInfo() {

--- a/src/main/java/app/iris/missingyou/controller/MemberController.java
+++ b/src/main/java/app/iris/missingyou/controller/MemberController.java
@@ -1,25 +1,21 @@
 package app.iris.missingyou.controller;
 
 import app.iris.missingyou.dto.MemberInfoDto;
-import app.iris.missingyou.dto.PostCreateResponseDto;
 import app.iris.missingyou.dto.PushInfoDto;
-import app.iris.missingyou.exception.ErrorResponse;
 import app.iris.missingyou.security.CustomUserDetails;
-import app.iris.missingyou.service.MemberService;
 import app.iris.missingyou.service.FCMService;
+import app.iris.missingyou.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.media.SchemaProperties;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController

--- a/src/main/java/app/iris/missingyou/controller/MemberController.java
+++ b/src/main/java/app/iris/missingyou/controller/MemberController.java
@@ -2,11 +2,16 @@ package app.iris.missingyou.controller;
 
 import app.iris.missingyou.dto.MemberInfoDto;
 import app.iris.missingyou.dto.PushInfoDto;
+import app.iris.missingyou.exception.ErrorResponse;
 import app.iris.missingyou.security.CustomUserDetails;
 import app.iris.missingyou.service.FCMService;
 import app.iris.missingyou.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -55,6 +60,13 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청 성공"),
+            @ApiResponse(responseCode = "204", description = "요청 성공(관심 지역이 설정되어 있지 않음)"),
+            @ApiResponse(responseCode = "403", description = "인증 헤더 누락"),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = { @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class)) })})
     @Operation(summary = "관심 지역 정보 조회", security = { @SecurityRequirement(name = "bearerAuth")})
     @GetMapping(value = "/members/push/region")
     public ResponseEntity<String> getPushRegion() {
@@ -62,6 +74,9 @@ public class MemberController {
 
         String regionName = pushService.getRegionInfo(principal);
 
-        return ResponseEntity.ok().body(regionName);
+        if(regionName != null)
+            return ResponseEntity.ok().body(regionName);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/app/iris/missingyou/controller/MemberController.java
+++ b/src/main/java/app/iris/missingyou/controller/MemberController.java
@@ -1,0 +1,28 @@
+package app.iris.missingyou.controller;
+
+import app.iris.missingyou.dto.MemberInfoDto;
+import app.iris.missingyou.security.CustomUserDetails;
+import app.iris.missingyou.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class MemberController {
+    private final MemberService memberService;
+
+    @Operation(summary = "유저 정보 요청", security = { @SecurityRequirement(name = "bearerAuth")})
+    @GetMapping(value = "/member")
+    public ResponseEntity<MemberInfoDto> getUserInfo() {
+        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        MemberInfoDto dto = memberService.get(principal);
+
+        return ResponseEntity.ok().body(dto);
+    }
+}

--- a/src/main/java/app/iris/missingyou/controller/MemberController.java
+++ b/src/main/java/app/iris/missingyou/controller/MemberController.java
@@ -45,18 +45,6 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "디바이스 토큰(기기 등록 토큰) 생성/수정(refresh)", security = { @SecurityRequirement(name = "bearerAuth")})
-    @PutMapping(value = "/members/push/device-token", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<?> postPushInfo(
-            @RequestBody String deviceToken
-    ) {
-        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-
-        pushService.setDeviceToken(principal, deviceToken);
-
-        return ResponseEntity.ok().build();
-    }
-
     @Operation(summary = "푸시 알림 정보 삭제", security = { @SecurityRequirement(name = "bearerAuth")})
     @DeleteMapping(value = "/members/push")
     public ResponseEntity<?> postPushInfo() {

--- a/src/main/java/app/iris/missingyou/controller/MemberController.java
+++ b/src/main/java/app/iris/missingyou/controller/MemberController.java
@@ -1,12 +1,19 @@
 package app.iris.missingyou.controller;
 
 import app.iris.missingyou.dto.MemberInfoDto;
+import app.iris.missingyou.dto.PostCreateResponseDto;
 import app.iris.missingyou.dto.PushInfoDto;
+import app.iris.missingyou.exception.ErrorResponse;
 import app.iris.missingyou.security.CustomUserDetails;
 import app.iris.missingyou.service.MemberService;
 import app.iris.missingyou.service.FCMService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.SchemaProperties;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -50,5 +57,15 @@ public class MemberController {
         pushService.delete(principal);
 
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "관심 지역 정보 조회", security = { @SecurityRequirement(name = "bearerAuth")})
+    @GetMapping(value = "/members/push/region")
+    public ResponseEntity<String> getPushRegion() {
+        CustomUserDetails principal = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        String regionName = pushService.getRegionInfo(principal);
+
+        return ResponseEntity.ok().body(regionName);
     }
 }

--- a/src/main/java/app/iris/missingyou/dto/PostCreateRequestDto.java
+++ b/src/main/java/app/iris/missingyou/dto/PostCreateRequestDto.java
@@ -32,6 +32,9 @@ public class PostCreateRequestDto {
     @Schema( type = "string", example = "서울시 용산구 갈월동 24")
     private String address;
 
+    @Schema(type = "string", example = "서울 강남구")
+    private String region;
+
     @NotBlank
     private double latitude;
     @NotBlank

--- a/src/main/java/app/iris/missingyou/dto/PushInfoDto.java
+++ b/src/main/java/app/iris/missingyou/dto/PushInfoDto.java
@@ -9,7 +9,6 @@ import lombok.*;
 @Getter
 @Setter
 public class PushInfoDto {
-
     private String region;
     @NotNull
     private String deviceToken;

--- a/src/main/java/app/iris/missingyou/dto/PushInfoDto.java
+++ b/src/main/java/app/iris/missingyou/dto/PushInfoDto.java
@@ -9,7 +9,7 @@ import lombok.*;
 @Getter
 @Setter
 public class PushInfoDto {
-    @NotNull
+
     private String region;
     @NotNull
     private String deviceToken;

--- a/src/main/java/app/iris/missingyou/dto/PushInfoDto.java
+++ b/src/main/java/app/iris/missingyou/dto/PushInfoDto.java
@@ -1,0 +1,17 @@
+package app.iris.missingyou.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Schema(description = "for [POST] /member/push request")
+@NoArgsConstructor
+@Getter
+@Setter
+public class PushInfoDto {
+    @NotNull
+    private String region;
+    @NotNull
+    private String deviceToken;
+}
+

--- a/src/main/java/app/iris/missingyou/entity/Push.java
+++ b/src/main/java/app/iris/missingyou/entity/Push.java
@@ -1,0 +1,20 @@
+package app.iris.missingyou.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Push extends TimeStamp {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(optional = false, fetch = FetchType.LAZY)
+    private Member member;
+
+    @Column(nullable = false)
+    private String deviceToken;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Region region;
+}

--- a/src/main/java/app/iris/missingyou/entity/Push.java
+++ b/src/main/java/app/iris/missingyou/entity/Push.java
@@ -19,7 +19,6 @@ public class Push extends TimeStamp {
     private String deviceToken;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private Region region;
 
     public Push (Member member) {

--- a/src/main/java/app/iris/missingyou/entity/Push.java
+++ b/src/main/java/app/iris/missingyou/entity/Push.java
@@ -1,7 +1,11 @@
 package app.iris.missingyou.entity;
 
 import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+@NoArgsConstructor
+@Setter
 @Entity
 public class Push extends TimeStamp {
     @Id
@@ -17,4 +21,12 @@ public class Push extends TimeStamp {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Region region;
+
+    public Push (Member member) {
+        this.member = member;
+    }
+
+    public Region getRegion() {
+        return region;
+    }
 }

--- a/src/main/java/app/iris/missingyou/entity/Region.java
+++ b/src/main/java/app/iris/missingyou/entity/Region.java
@@ -1,5 +1,11 @@
 package app.iris.missingyou.entity;
 
+import app.iris.missingyou.exception.CustomException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.springframework.http.HttpStatus;
+
 public enum Region {
     //서울
     SEOUL_GANGNAMGU("서울 강남구"),
@@ -30,11 +36,21 @@ public enum Region {
 
     private final String name;
 
-    Region(String name) {
+    Region(String name){
         this.name = name;
     }
 
+    @JsonValue
     public String getName() {
         return name;
+    }
+
+    @JsonCreator
+    public static Region fromName(@JsonProperty("name") String name) {
+        for(Region region : values()) {
+            if(region.getName().equals(name))
+                return region;
+        }
+        throw new CustomException(HttpStatus.BAD_REQUEST, "지원되지 않는 지역: "+name);
     }
 }

--- a/src/main/java/app/iris/missingyou/entity/Region.java
+++ b/src/main/java/app/iris/missingyou/entity/Region.java
@@ -1,0 +1,40 @@
+package app.iris.missingyou.entity;
+
+public enum Region {
+    //서울
+    SEOUL_GANGNAMGU("서울 강남구"),
+    SEOUL_GANGDONGGU("서울 강동구"),
+    SEOUL_GANGBUKGU("서울 강북구"),
+    SEOUL_GANGSEOGU("서울 강서구"),
+    SEOUL_GWANGAKGU("서울 관악구"),
+    SEOUL_GWANGJINGU("서울 광진구"),
+    SEOUL_GUROGU("서울 구로구"),
+    SEOUL_GEUMCHEONGU("서울 금천구"),
+    SEOUL_NOWONGU("서울 노원구"),
+    SEOUL_DOBONGGU("서울 도봉구"),
+    SEOUL_DONGDAEMUNGU("서울 동대문구"),
+    SEOUL_DONGJAKGU("서울 동작구"),
+    SEOUL_MAPOGU("서울 마포구"),
+    SEOUL_SEODAEMUNGU("서울 서대문구"),
+    SEOUL_SEOCHOGU("서울 서초구"),
+    SEOUL_SEONGDONGGU("서울 성동구"),
+    SEOUL_SEONGBUKGU("서울 성북구"),
+    SEOUL_SONGPAGU("서울 송파구"),
+    SEOUL_YANGCHEONGU("서울 양천구"),
+    SEOUL_YEONGDEUNGPOGU("서울 영등포구"),
+    SEOUL_YONGSANGU("서울 용산구"),
+    SEOUL_EUNPYEONGU("서울 은평구"),
+    SEOUL_JONGNOGU("서울 종로구"),
+    SEOUL_JUNGGU("서울 중구"),
+    SEOUL_JUNGLANGGU("서울 중랑구");
+
+    private final String name;
+
+    Region(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/app/iris/missingyou/repository/PushRepository.java
+++ b/src/main/java/app/iris/missingyou/repository/PushRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository

--- a/src/main/java/app/iris/missingyou/repository/PushRepository.java
+++ b/src/main/java/app/iris/missingyou/repository/PushRepository.java
@@ -1,0 +1,12 @@
+package app.iris.missingyou.repository;
+
+import app.iris.missingyou.entity.Push;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PushRepository extends JpaRepository<Push, Long> {
+    Optional<Push> findByMemberId(Long memberId);
+}

--- a/src/main/java/app/iris/missingyou/repository/PushRepository.java
+++ b/src/main/java/app/iris/missingyou/repository/PushRepository.java
@@ -1,12 +1,22 @@
 package app.iris.missingyou.repository;
 
 import app.iris.missingyou.entity.Push;
+import app.iris.missingyou.entity.Region;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface PushRepository extends JpaRepository<Push, Long> {
     Optional<Push> findByMemberId(Long memberId);
+
+    @Query("SELECT p.deviceToken FROM Push p "
+            +"WHERE p.region = :region AND p.deviceToken IS NOT NULL "
+            + "ORDER BY p.updatedAt DESC")
+    Page<String> findAllDeviceToken(Region region, Pageable pageable);
 }

--- a/src/main/java/app/iris/missingyou/service/FCMService.java
+++ b/src/main/java/app/iris/missingyou/service/FCMService.java
@@ -32,14 +32,14 @@ public class FCMService {
                 ()->new CustomException(HttpStatus.NOT_FOUND, "해당 자원을 찾을 수 없습니다.")
         );
 
-        return push.getRegion().getName();
+        return push.getRegion() != null ? push.getRegion().getName() : null;
     }
 
     public void setPushInfo(CustomUserDetails userDetails, PushInfoDto dto) {
         Member member = memberService.findById(Long.parseLong(userDetails.getUsername()));
         Push push = pushRepository.findByMemberId(member.getId()).orElse(new Push(member));
 
-        if(dto.getRegion() != null){
+        if(!dto.getRegion().isEmpty()){
             Region region = Region.fromName(dto.getRegion());
             push.setRegion(region);
         }

--- a/src/main/java/app/iris/missingyou/service/FCMService.java
+++ b/src/main/java/app/iris/missingyou/service/FCMService.java
@@ -39,19 +39,12 @@ public class FCMService {
         Member member = memberService.findById(Long.parseLong(userDetails.getUsername()));
         Push push = pushRepository.findByMemberId(member.getId()).orElse(new Push(member));
 
-        Region region = Region.fromName(dto.getRegion());
-
+        if(dto.getRegion() != null){
+            Region region = Region.fromName(dto.getRegion());
+            push.setRegion(region);
+        }
         push.setDeviceToken(dto.getDeviceToken());
-        push.setRegion(region);
 
-        pushRepository.save(push);
-    }
-
-    public void setDeviceToken(CustomUserDetails userDetails, String deviceToken) {
-        Member member = memberService.findById(Long.parseLong(userDetails.getUsername()));
-        Push push = pushRepository.findByMemberId(member.getId()).orElse(new Push(member));
-
-        push.setDeviceToken(deviceToken);
         pushRepository.save(push);
     }
 

--- a/src/main/java/app/iris/missingyou/service/FCMService.java
+++ b/src/main/java/app/iris/missingyou/service/FCMService.java
@@ -1,0 +1,102 @@
+package app.iris.missingyou.service;
+
+import app.iris.missingyou.dto.PushInfoDto;
+import app.iris.missingyou.entity.Member;
+import app.iris.missingyou.entity.Push;
+import app.iris.missingyou.entity.Region;
+import app.iris.missingyou.exception.CustomException;
+import app.iris.missingyou.repository.PushRepository;
+import app.iris.missingyou.security.CustomUserDetails;
+import com.google.firebase.messaging.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class FCMService {
+    private final MemberService memberService;
+    private final PushRepository pushRepository;
+
+    public void setPushInfo(CustomUserDetails userDetails, PushInfoDto dto) {
+        Member member = memberService.findById(Long.parseLong(userDetails.getUsername()));
+        Push push = pushRepository.findByMemberId(member.getId()).orElse(new Push(member));
+
+        Region region = Region.fromName(dto.getRegion());
+        if(region != push.getRegion() )
+            unsubcribeTopic(dto.getDeviceToken(), region);
+        subscribeTopic(dto.getDeviceToken(), region);
+
+        push.setDeviceToken(dto.getDeviceToken());
+        push.setRegion(region);
+
+        pushRepository.save(push);
+    }
+
+    public void delete(CustomUserDetails userDetails) {
+        Member member = memberService.findById(Long.parseLong(userDetails.getUsername()));
+        Push push = pushRepository.findByMemberId(member.getId()).orElseThrow(
+                ()->new CustomException(HttpStatus.NOT_FOUND, "해당 자원을 찾을 수 없습니다.")
+        );
+
+        pushRepository.delete(push);
+    }
+
+    public void subscribeTopic(String deviceToken, Region region) {
+        List<String> registrationTokens = new ArrayList<>();
+        registrationTokens.add(deviceToken);
+        TopicManagementResponse response;
+        try {
+           response = FirebaseMessaging.getInstance()
+                   .subscribeToTopic(registrationTokens, region.name());
+        }  catch (FirebaseMessagingException e) {
+            log.error("fail to subscribe: fcm[ " + e.getErrorCode()+"]"+ e.getMessage() );
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "fcm 서버와 통신에 실패했습니다.");
+        } catch (Exception e) {
+            log.error("fail to unsubscribe: "+e.getMessage());
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "FCM 서버와 통신에 실패했습니다.");
+        }
+    }
+
+    public void unsubcribeTopic(String deviceToken, Region region) {
+        List<String> registrationTokens = new ArrayList<>();
+        registrationTokens.add(deviceToken);
+        TopicManagementResponse response;
+        try {
+            response = FirebaseMessaging.getInstance().unsubscribeFromTopic(
+                    registrationTokens, region.name());
+        } catch (FirebaseMessagingException e) {
+            log.error("fail to unsubscribe: fcm[ " + e.getErrorCode()+"]"+ e.getMessage() );
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "fcm 서버와 통신에 실패했습니다.");
+        } catch (Exception e) {
+            log.error("fail to unsubscribe: "+e.getMessage());
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "FCM 서버와 통신에 실패했습니다.");
+        }
+    }
+
+    @Async
+    public void sendPush(Long pid, String regionName) {
+        try {
+            Region region = Region.fromName(regionName);
+
+            Message message = Message.builder()
+                    .setNotification(Notification.builder()
+                            .setTitle("새로운 실종 정보")
+                            .setBody(regionName+"에서 새로운 실종 정보가 등록되었습니다.")
+                            .build())
+                    .setTopic(region.name())
+                    .build();
+            String response = FirebaseMessaging.getInstance().send(message);
+        } catch (FirebaseMessagingException e) {
+            log.error("fail to send message: fcm[ " + e.getErrorCode()+"]"+ e.getMessage() );
+        } catch (Exception e) {
+            log.error("fail to send message: "+e.getMessage());
+        }
+    }
+}

--- a/src/main/java/app/iris/missingyou/service/FCMService.java
+++ b/src/main/java/app/iris/missingyou/service/FCMService.java
@@ -24,6 +24,15 @@ public class FCMService {
     private final MemberService memberService;
     private final PushRepository pushRepository;
 
+    public String getRegionInfo(CustomUserDetails userDetails) {
+        Member member = memberService.findById(Long.parseLong(userDetails.getUsername()));
+        Push push = pushRepository.findByMemberId(member.getId()).orElseThrow(
+                ()->new CustomException(HttpStatus.NOT_FOUND, "해당 자원을 찾을 수 없습니다.")
+        );
+
+        return push.getRegion().getName();
+    }
+
     public void setPushInfo(CustomUserDetails userDetails, PushInfoDto dto) {
         Member member = memberService.findById(Long.parseLong(userDetails.getUsername()));
         Push push = pushRepository.findByMemberId(member.getId()).orElse(new Push(member));

--- a/src/main/java/app/iris/missingyou/service/FCMService.java
+++ b/src/main/java/app/iris/missingyou/service/FCMService.java
@@ -48,6 +48,14 @@ public class FCMService {
         pushRepository.save(push);
     }
 
+    public void setDeviceToken(CustomUserDetails userDetails, String deviceToken) {
+        Member member = memberService.findById(Long.parseLong(userDetails.getUsername()));
+        Push push = pushRepository.findByMemberId(member.getId()).orElse(new Push(member));
+
+        push.setDeviceToken(deviceToken);
+        pushRepository.save(push);
+    }
+
     public void delete(CustomUserDetails userDetails) {
         Member member = memberService.findById(Long.parseLong(userDetails.getUsername()));
         Push push = pushRepository.findByMemberId(member.getId()).orElseThrow(

--- a/src/main/java/app/iris/missingyou/service/PostService.java
+++ b/src/main/java/app/iris/missingyou/service/PostService.java
@@ -28,6 +28,7 @@ public class PostService {
     private final CommentRepository commentRepository;
     private final MemberService memberService;
     private final ImgStorageService imgStorageService;
+    private final FCMService fcmService;
 
     public Post get(Long postId) {
         return postRepository.findById(postId)
@@ -58,6 +59,8 @@ public class PostService {
         imgStorageService.createImage(requestDto.getImages(), post);
 
         String genImageUrl = imgStorageService.createGenImage(post);
+
+        fcmService.sendPush(post.getId(), requestDto.getRegion());
 
         return new PostCreateResponseDto(genImageUrl, post.getId());
     }


### PR DESCRIPTION
## 개요
- FCM을 이용한 푸시 알림 기능 도입
- 관심지역에 실종 정보가 등록되면 푸시 알림 전송

## 작업사항
- 푸시 알림 관련 정보 관리를 위한 entity class를 추가했습니다.
- [PUT] /members/push : 푸시 알림 정보 생성/수정
  - 디바이스 토큰과 관심지역 설정을 위한 API입니다.
  - 등록을 위한 POST 메소드와 수정을 위한 PATCH 메소드로 분리하기 보다는 PUT 메소드를 이용해 하나의 API로 개발했습니다. 
  - [PUT] /members/push/device-token : 디바이스 토큰(기기 등록 토큰) 생성/수정(refresh) 가 있었으나, region을 null로 받아 디바이스 토큰 리프레시 API로도 사용하도록 변경하였습니다.
   (HTTP PUT 메소드 스펙을 맞추려면 추가 API가 몇개나 생겨야할 것 같음. 최소한의 API로 구현)
   
- [DELETE] /members/push
  - 사용자가 알림 해제 시 푸시 알림 정보를 삭제하기 위한 API
  
- [GET] /members/push/region
  - 관심지역 정보 얻기 위한 API
  
## 알림사항
- region은 축약형(ex. "서울 용산구")으로 요청해주시고. 잘못된 지역명일 시 다음과 같은 err 리스폰스 리턴
```
{
  "timestamp": "2024-04-25T14:58:27.178696192",
  "status": 400,
  "message": "BAD_REQUEST",
  "details": "지원되지 않는 지역: 서울시 용산구"
}
```
- 주제 메시지 타겟팅 구현에서 등록 토큰 기반 메시지 타켓팅 구현으로 변경하였습니다.
  - 사용자 본인이 등록한 글에 대해서도 알림이 가는 문제를 해결하기 위해 변경 
